### PR TITLE
feat: cache and rank map results

### DIFF
--- a/backend/services/maps_service.py
+++ b/backend/services/maps_service.py
@@ -69,8 +69,14 @@ class MapService:
                         ),
                     }
                     results.append(processed)
+                # Sort places by rating and number of ratings (both descending)
+                results.sort(
+                    key=lambda p: (p.get("rating", 0), p.get("user_ratings_total", 0)),
+                    reverse=True,
+                )
 
-                return results
+                # Limit to top 10 results
+                return results[:10]
             except Exception as e:
                 print(f"🚨 MapService Error: {e}")
                 return None


### PR DESCRIPTION
## Summary
- cache previous place search results and use them for follow-up questions
- rank Google Maps results by rating and limit to the top 10
- detect follow-up intent with LLM rather than simple keywords

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1dc7fe0ac832487a3d4e6e1ae6fe0