### PR TITLE
feat: add dummy auth with rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,9 @@ BACKEND_PORT=8000
 FRONTEND_PORT=5173
 OLLAMA_PORT=11434
 
-# auth for backend
-BACKEND_BEARER=change_me_strong_token
+# dummy auth for backend
+DUMMY_BYPASS_UNAME=admin
+DUMMY_BYPASS_PASSWORD=password
 
 # Google
 GMAPS_SERVER_KEY=Axxxx

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ A full-stack application with FastAPI backend and React frontend for place searc
    GMAPS_SERVER_KEY=your_google_maps_server_api_key
    GMAPS_EMBED_KEY=your_google_maps_embed_api_key
 
-   # Backend Configuration
-   BACKEND_BEARER=your_secure_bearer_token
+   # Auth Configuration
+   DUMMY_BYPASS_UNAME=your_username
+   DUMMY_BYPASS_PASSWORD=your_password
    FRONTEND_ORIGIN=http://localhost:5173
    ```
 
@@ -114,9 +115,15 @@ Once the backend is running, visit:
 
 ### Authentication
 
-API endpoints require Bearer token authentication:
+Request a token using the `/v1/auth` endpoint with the dummy credentials:
 ```bash
-Authorization: Bearer your_backend_bearer_token
+curl -X POST http://localhost:8000/v1/auth -H "Content-Type: application/json" \
+  -d '{"username":"your_username","password":"your_password"}'
+```
+
+Use the returned token for authenticated requests:
+```bash
+Authorization: Bearer <token>
 ```
 
 ## Testing
@@ -150,7 +157,8 @@ npm run test:coverage
 1. **Update environment variables for production**
    ```env
    FRONTEND_ORIGIN=https://your-domain.com
-   BACKEND_BEARER=secure_production_token
+   DUMMY_BYPASS_UNAME=your_username
+   DUMMY_BYPASS_PASSWORD=your_password
    ```
 
 2. **Build and deploy with Docker Compose**
@@ -214,7 +222,8 @@ npx serve -s dist -l 5173
 |----------|-------------|----------|----------|
 | `GMAPS_SERVER_KEY` | Google Maps Server API Key | Yes | - |
 | `GMAPS_EMBED_KEY` | Google Maps Embed API Key | Yes | - |
-| `BACKEND_BEARER` | Backend API authentication token | No | `change_me_strong_token` |
+| `DUMMY_BYPASS_UNAME` | Dummy username for auth | No | `admin` |
+| `DUMMY_BYPASS_PASSWORD` | Dummy password for auth | No | `password` |
 | `FRONTEND_ORIGIN` | Frontend URL for CORS | No | `http://localhost:5173` |
 
 ## Troubleshooting

--- a/backend/configs/envs.py
+++ b/backend/configs/envs.py
@@ -6,7 +6,8 @@ class Config:
 
   # Server Configuration
   FRONTEND_ORIGIN: str = os.getenv("FRONTEND_ORIGIN", "http://localhost:5173")
-  BACKEND_BEARER: str = os.getenv("BACKEND_BEARER", "change_me_strong_token")
+  DUMMY_BYPASS_UNAME: str = os.getenv("DUMMY_BYPASS_UNAME", "admin")
+  DUMMY_BYPASS_PASSWORD: str = os.getenv("DUMMY_BYPASS_PASSWORD", "password")
 
   # LLM Configuration
   USE_LOCAL_LLM: bool = os.getenv("USE_LOCAL_LLM", "false").lower() == "true"

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,12 +3,20 @@ from fastapi.middleware.cors import CORSMiddleware
 import logging
 from services.llm_service import LLMService, ChatRequest, ChatResponse
 from configs.envs import config
+from pydantic import BaseModel
+from typing import Dict, List
+from datetime import datetime, timedelta
+import uuid
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+
+TOKEN_REQUESTS: Dict[str, List[datetime]] = {}
+RATE_LIMIT = 10
+RATE_WINDOW = timedelta(minutes=30)
 
 app.add_middleware(
   CORSMiddleware,
@@ -18,14 +26,40 @@ app.add_middleware(
   allow_headers=["*"],
 )
 
+class AuthRequest(BaseModel):
+  username: str
+  password: str
+
+class AuthResponse(BaseModel):
+  token: str
+
 @app.get("/healthz")
 async def healthz():
   return {"ok": True}
 
+@app.post("/v1/auth", response_model=AuthResponse)
+async def auth(body: AuthRequest):
+  if body.username == config.DUMMY_BYPASS_UNAME and body.password == config.DUMMY_BYPASS_PASSWORD:
+    token = uuid.uuid4().hex
+    TOKEN_REQUESTS[token] = []
+    return {"token": token}
+  raise HTTPException(status_code=401, detail="invalid credentials")
+
 @app.post("/v1/chat", response_model=ChatResponse)
 async def chat(body: ChatRequest, authorization: str = Header(None)):
-  if authorization != f"Bearer {config.BACKEND_BEARER}":
+  if not authorization or not authorization.startswith("Bearer "):
     raise HTTPException(status_code=401, detail="unauthorized")
+
+  token = authorization.split(" ", 1)[1]
+  if token not in TOKEN_REQUESTS:
+    raise HTTPException(status_code=401, detail="unauthorized")
+
+  now = datetime.utcnow()
+  recent = [t for t in TOKEN_REQUESTS[token] if now - t < RATE_WINDOW]
+  if len(recent) >= RATE_LIMIT:
+    raise HTTPException(status_code=429, detail="rate limit exceeded")
+  recent.append(now)
+  TOKEN_REQUESTS[token] = recent
 
   try:
     logger.info(f"💬 Chat request: '{body.message}'")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,8 @@ services:
       # force polling on Mac/VM for stable reload
       - WATCHFILES_FORCE_POLLING=true
       - FRONTEND_ORIGIN=http://localhost:${FRONTEND_PORT}
-      - BACKEND_BEARER=${BACKEND_BEARER}
+      - DUMMY_BYPASS_UNAME=${DUMMY_BYPASS_UNAME}
+      - DUMMY_BYPASS_PASSWORD=${DUMMY_BYPASS_PASSWORD}
       - GMAPS_SERVER_KEY=${GMAPS_SERVER_KEY}
       - GMAPS_EMBED_KEY=${GMAPS_EMBED_KEY}
       - CLOUD_LLM_API_KEY=${CLOUD_LLM_API_KEY}
@@ -25,7 +26,6 @@ services:
       - ./frontend:/app
     environment:
       - VITE_BACKEND_URL=http://localhost:${BACKEND_PORT}
-      - VITE_BACKEND_BEARER=${BACKEND_BEARER}
       - VITE_GOOGLE_MAPS_EMBED_KEY=${GMAPS_EMBED_KEY}
       - CHOKIDAR_USEPOLLING=true # vite in Mac sometimes requires pooling
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     env_file: ./.env
     environment:
       - BACKEND_PORT=${BACKEND_PORT}
-      - BACKEND_BEARER=${BACKEND_BEARER}
+      - DUMMY_BYPASS_UNAME=${DUMMY_BYPASS_UNAME}
+      - DUMMY_BYPASS_PASSWORD=${DUMMY_BYPASS_PASSWORD}
       - GMAPS_SERVER_KEY=${GMAPS_SERVER_KEY}
       - GMAPS_EMBED_KEY=${GMAPS_EMBED_KEY}
       - FRONTEND_ORIGIN=http://localhost:${FRONTEND_PORT}
@@ -23,7 +24,6 @@ services:
     container_name: frontend
     environment:
       - VITE_BACKEND_URL=http://localhost:8000
-      - VITE_BACKEND_BEARER=${BACKEND_BEARER}
       - VITE_GOOGLE_MAPS_EMBED_KEY=${GMAPS_EMBED_KEY}
     ports:
       - "${FRONTEND_PORT}:80"

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,5 @@
 # Backend API Configuration
 VITE_BACKEND_URL=http://localhost:8000
-VITE_BACKEND_BEARER=change_me_strong_token
 
 # Google Maps API Configuration
 VITE_GOOGLE_MAPS_EMBED_KEY=AIzaSyDQfjluVFtpRHG5VrnFuSdnRsIJfYDS9XI

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,81 @@
+import { useState } from 'react';
 import AIChatRoom from '@/modules/AIChat/components/AIChatRoom';
+import { BACKEND_URL } from '@/configs/envs';
 
 function App() {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = async () => {
+    setError('');
+    try {
+      const res = await fetch(`${BACKEND_URL}/v1/auth`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) {
+        setError('Invalid credentials');
+        return;
+      }
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      setToken(data.token);
+    } catch {
+      setError('Login failed');
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-base-100">
+        <div className="card w-96 bg-base-200 shadow-xl">
+          <div className="card-body space-y-4">
+            <h2 className="card-title">Login</h2>
+            {error && <p className="text-error text-sm">{error}</p>}
+            <input
+              className="input input-bordered w-full"
+              placeholder="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+            <input
+              type="password"
+              className="input input-bordered w-full"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <button className="btn btn-primary w-full" onClick={handleLogin}>
+              Login
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-base-100">
       <div className="container mx-auto px-4 py-6 max-w-4xl">
         {/* Header */}
-        <div className="text-center mb-6">
+        <div className="text-center mb-6 relative">
           <h1 className="text-3xl font-bold text-base-content mb-2">
             HeyPico AI Chat
           </h1>
           <p className="text-base-content/70">
             Chat with AI assistant
           </p>
+          <button className="btn btn-sm btn-outline absolute right-0 top-0" onClick={handleLogout}>
+            Logout
+          </button>
         </div>
 
         {/* Chat Container */}

--- a/frontend/src/configs/envs.ts
+++ b/frontend/src/configs/envs.ts
@@ -1,2 +1,1 @@
 export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'
-export const BACKEND_BEARER = import.meta.env.VITE_BACKEND_BEARER || 'change_me_strong_token'

--- a/frontend/src/modules/AIChat/AIChat.api.ts
+++ b/frontend/src/modules/AIChat/AIChat.api.ts
@@ -1,4 +1,4 @@
-import { BACKEND_BEARER, BACKEND_URL } from "../../configs/envs";
+import { BACKEND_URL } from "../../configs/envs";
 import BaseHttp from "../../libs/BaseHttp";
 
 export interface Location {
@@ -30,15 +30,16 @@ export interface ChatResponse {
   places?: PlaceResult[];
 }
 
-const Http = new BaseHttp({
-  baseURL: BACKEND_URL,
-  headers: {
-    'Authorization': `Bearer ${BACKEND_BEARER}`,
-    'Content-Type': 'application/json'
-  }
-})
-
 export async function chat(_userMsg: ChatMessage, _history: ChatMessage[]) {
+  const token = localStorage.getItem('token') || ''
+  const Http = new BaseHttp({
+    baseURL: BACKEND_URL,
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  })
+
   const response = await Http.post(`/v1/chat`, {
     body: JSON.stringify({
       message: _userMsg.content,


### PR DESCRIPTION
## Summary
- add `/v1/auth` endpoint that issues tokens when dummy env credentials match
- enforce per-token rate limit of 10 chat requests per 30 minutes
- implement login form on frontend and attach token to chat requests

## Testing
- `python -m py_compile backend/main.py backend/configs/envs.py`
- `python -m pytest`
- `cd frontend && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1e32af4148324ba0aabd9ad39a585