### PR TITLE
fix: simplify backend Dockerfile paths

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.11-slim
 
 WORKDIR /app
-COPY backend/requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY backend /app
+COPY . /app
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- use root requirements.txt in backend Dockerfile
- copy entire context into /app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a213e020b8832495ced470138c880b